### PR TITLE
:bug: Ensure the operations make use of base_url in spite of what (cached) schema contains

### DIFF
--- a/zds_client/client.py
+++ b/zds_client/client.py
@@ -242,33 +242,33 @@ class Client:
 
     def list(self, resource: str, query_params=None, **path_kwargs) -> List[Object]:
         operation_id = '{resource}_list'.format(resource=resource)
-        url = get_operation_url(self.schema, operation_id, **path_kwargs)
+        url = get_operation_url(self.schema, operation_id, base_url=self.base_url, **path_kwargs)
         return self.request(url, operation_id, params=query_params)
 
     def retrieve(self, resource: str, url=None, **path_kwargs) -> Object:
         operation_id = '{resource}_read'.format(resource=resource)
         if url is None:
-            url = get_operation_url(self.schema, operation_id, **path_kwargs)
+            url = get_operation_url(self.schema, operation_id, base_url=self.base_url, **path_kwargs)
         return self.request(url, operation_id)
 
     def create(self, resource: str, data: dict, **path_kwargs) -> Object:
         operation_id = '{resource}_create'.format(resource=resource)
-        url = get_operation_url(self.schema, operation_id, **path_kwargs)
+        url = get_operation_url(self.schema, operation_id, base_url=self.base_url, **path_kwargs)
         return self.request(url, operation_id, method='POST', json=data, expected_status=201)
 
     def update(self, resource: str, data: dict, url=None, **path_kwargs) -> Object:
         operation_id = '{resource}_update'.format(resource=resource)
         if url is None:
-            url = get_operation_url(self.schema, operation_id, **path_kwargs)
+            url = get_operation_url(self.schema, operation_id, base_url=self.base_url, **path_kwargs)
         return self.request(url, operation_id, method='PUT', json=data, expected_status=200)
 
     def partial_update(self, resource: str, data: dict, url=None, **path_kwargs) -> Object:
         operation_id = '{resource}_partial_update'.format(resource=resource)
         if url is None:
-            url = get_operation_url(self.schema, operation_id, **path_kwargs)
+            url = get_operation_url(self.schema, operation_id, base_url=self.base_url, **path_kwargs)
         return self.request(url, operation_id, method='PATCH', json=data, expected_status=200)
 
     def operation(self, operation_id: str, data: dict, url=None, **path_kwargs) -> Union[List[Object], Object]:
         if url is None:
-            url = get_operation_url(self.schema, operation_id, **path_kwargs)
+            url = get_operation_url(self.schema, operation_id, base_url=self.base_url, **path_kwargs)
         return self.request(url, operation_id, method='POST', json=data)

--- a/zds_client/schema.py
+++ b/zds_client/schema.py
@@ -11,8 +11,8 @@ DEFAULT_PATH_PARAMETERS = {
 TYPE_ARRAY = 'array'
 
 
-def get_operation_url(spec: dict, operation: str, pattern_only=False, **kwargs) -> str:
-    url = spec['servers'][0]['url']
+def get_operation_url(spec: dict, operation: str, pattern_only=False, base_url=None, **kwargs) -> str:
+    url = spec['servers'][0]['url'] if not base_url else base_url
     base_path = urlparse(url).path
 
     for path, methods in spec['paths'].items():


### PR DESCRIPTION
Next to the Python35 problems, the main problem we had with expanding gemma-zaken-demo with a working test against the test-platform was that the zds_client appeared to be using a different base_url than configured.

I'm not sure why this works though (the schema-stuff seems complicated), however after Joeri dictated these changes things worked as expected :)